### PR TITLE
Link u-track output to image

### DIFF
--- a/link_utrack_out
+++ b/link_utrack_out
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+
+import sys
+import os
+
+lib = os.path.expanduser("~/OMERO.server/lib/python")
+if not os.path.isdir(lib):
+    sys.exit("cannot import libraries from %s" % lib)
+sys.path.insert(0, lib)
+
+import uuid
+
+import scipy.io
+import omero
+from omero.cli import CLI
+from omero.cli import Parser
+from omero.rtypes import unwrap
+
+
+def build_table(shared_res, utrack_out_fn):
+    mat = scipy.io.loadmat(utrack_out_fn)
+    trackedFeatureIndx = mat['trackedFeatureIndx']
+    trackedFeatureInfo = mat['trackedFeatureInfo']
+    n_rows = trackedFeatureIndx.shape[0]
+    assert trackedFeatureInfo.shape[0] == n_rows
+    assert trackedFeatureInfo.shape[1] == 8 * trackedFeatureIndx.shape[1]
+    #--
+    table_name = 'utrack_%s' % uuid.uuid4()
+    print "creating table: %s" % table_name
+    columns = [
+        omero.grid.LongArrayColumn(
+            'trackedFeatureIndx', 'Array', trackedFeatureIndx.shape[1]
+        ),
+        omero.grid.DoubleArrayColumn(
+            'trackedFeatureInfo', 'Array', trackedFeatureInfo.shape[1]
+        ),
+    ]
+    table = shared_res.newTable(1, table_name)
+    table.initialize(columns)
+    table.addData([
+        omero.grid.LongArrayColumn(
+            'trackedFeatureIndx', 'Array', trackedFeatureIndx.shape[1],
+            list(trackedFeatureIndx)
+        ),
+        omero.grid.DoubleArrayColumn(
+            'trackedFeatureInfo', 'Array', trackedFeatureInfo.shape[1],
+            list(trackedFeatureInfo)
+        ),
+    ])
+    table.close()
+    return table
+
+
+def link_table(update_svc, table, img_id):
+    of_id = unwrap(table.getOriginalFile().id)
+    ann = omero.model.FileAnnotationI()
+    ann.setFile(omero.model.OriginalFileI(of_id, False))
+    ann = update_svc.saveAndReturnObject(ann)
+    ann_id = unwrap(ann.id)
+    link = omero.model.ImageAnnotationLinkI()
+    link.setParent(omero.model.ImageI(img_id, False))
+    link.setChild(omero.model.FileAnnotationI(ann_id, False))
+    return update_svc.saveAndReturnObject(link)
+
+
+def main():
+    parser = Parser()
+    parser.add_login_arguments()
+    parser.add_argument("utrack_results", metavar="RES_FILE",
+                        help="u-track results file")
+    parser.add_argument("img_id", metavar="IMG_ID",
+                        help="ID of image to link table to")
+    args = parser.parse_args()
+
+    cli = CLI()
+    cli.loadplugins()
+    client = cli.conn(args)
+    admin_svc = client.sf.getAdminService()
+    shared_res = client.sf.sharedResources()
+    update_svc = client.sf.getUpdateService()
+
+    try:
+        g = admin_svc.getGroup(admin_svc.getEventContext().groupId)
+        print "current group: %s[%d]" % (unwrap(g.getName()), unwrap(g.id))
+        table = build_table(shared_res, args.utrack_results)
+        link = link_table(update_svc, table, args.img_id)
+        print "ImageAnnotationLink:%d" % unwrap(link.id)
+    finally:
+        cli.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/link_utrack_out
+++ b/link_utrack_out
@@ -10,6 +10,7 @@ sys.path.insert(0, lib)
 
 import uuid
 
+import numpy as np
 import scipy.io
 import omero
 from omero.cli import CLI
@@ -17,10 +18,20 @@ from omero.cli import Parser
 from omero.rtypes import unwrap
 
 
-def build_table(shared_res, utrack_out_fn):
-    mat = scipy.io.loadmat(utrack_out_fn)
-    trackedFeatureIndx = mat['trackedFeatureIndx']
-    trackedFeatureInfo = mat['trackedFeatureInfo']
+def build_table(shared_res, utrack_out, csv=False, delimiter=","):
+    if csv:
+        trackedFeatureIndx = np.loadtxt(
+            os.path.join(utrack_out, "trackedFeatureIndx.csv"),
+            delimiter=delimiter, dtype="<u2"
+        )
+        trackedFeatureInfo = np.loadtxt(
+            os.path.join(utrack_out, "trackedFeatureInfo.csv"),
+            delimiter=delimiter, dtype="<f8"
+        )
+    else:
+        mat = scipy.io.loadmat(utrack_out)
+        trackedFeatureIndx = mat['trackedFeatureIndx']
+        trackedFeatureInfo = mat['trackedFeatureInfo']
     n_rows = trackedFeatureIndx.shape[0]
     assert trackedFeatureInfo.shape[0] == n_rows
     assert trackedFeatureInfo.shape[1] == 8 * trackedFeatureIndx.shape[1]
@@ -40,11 +51,11 @@ def build_table(shared_res, utrack_out_fn):
     table.addData([
         omero.grid.LongArrayColumn(
             'trackedFeatureIndx', 'Array', trackedFeatureIndx.shape[1],
-            list(trackedFeatureIndx)
+            trackedFeatureIndx.tolist()
         ),
         omero.grid.DoubleArrayColumn(
             'trackedFeatureInfo', 'Array', trackedFeatureInfo.shape[1],
-            list(trackedFeatureInfo)
+            trackedFeatureInfo.tolist()
         ),
     ])
     table.close()
@@ -67,9 +78,13 @@ def main():
     parser = Parser()
     parser.add_login_arguments()
     parser.add_argument("utrack_results", metavar="RES_FILE",
-                        help="u-track results file")
+                        help="u-track results file (or dir for csv dumps)")
     parser.add_argument("img_id", metavar="IMG_ID",
                         help="ID of image to link table to")
+    parser.add_argument("--csv", action="store_true",
+                        help="read data from csv dumps instead of .mat")
+    parser.add_argument("-d", "--delimiter", metavar="STRING", default=",",
+                        help="field delimiter (ignored if reading from .mat)")
     args = parser.parse_args()
 
     cli = CLI()
@@ -82,7 +97,8 @@ def main():
     try:
         g = admin_svc.getGroup(admin_svc.getEventContext().groupId)
         print "current group: %s[%d]" % (unwrap(g.getName()), unwrap(g.id))
-        table = build_table(shared_res, args.utrack_results)
+        table = build_table(shared_res, args.utrack_results, csv=args.csv,
+                            delimiter=args.delimiter)
         link = link_table(update_svc, table, args.img_id)
         print "ImageAnnotationLink:%d" % unwrap(link.id)
     finally:

--- a/utrack_mat_to_csv
+++ b/utrack_mat_to_csv
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+"""\
+Convert u-track output from .mat to .csv.
+"""
+
+import sys
+import os
+import errno
+import argparse
+
+import numpy as np
+import scipy.io
+
+
+def csv_dump(mat, out_d, delimiter=","):
+    for name, arr in mat.iteritems():
+        if name.startswith("__"):
+            continue
+        out_fn = os.path.join(out_d, "%s.csv" % name)
+        fmt = "%d" if issubclass(arr.dtype.type, np.integer) else "%.18e"
+        print "writing to %s" % out_fn
+        np.savetxt(out_fn, arr, fmt=fmt, delimiter=delimiter)
+
+
+def make_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('mat_fn', metavar="MAT_FILE", help="input .mat file")
+    parser.add_argument("-o", "--out-dir", metavar="DIR",
+                        help="output directory", default=os.getcwd())
+    parser.add_argument("-d", "--delimiter", metavar="STRING",
+                        help="field delimiter", default=",")
+    return parser
+
+
+def main(argv):
+    parser = make_parser()
+    args = parser.parse_args(argv[1:])
+    mat = scipy.io.loadmat(args.mat_fn)
+    try:
+        print mat["__header__"]
+    except KeyError:
+        pass
+    try:
+        os.makedirs(args.out_dir)
+    except OSError as e:
+        if e.errno == errno.EEXIST:
+            pass
+    csv_dump(mat, args.out_dir, delimiter=args.delimiter)
+
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
Adds a script to link u-track analysis results to an image (which should be the one those results have been obtained from, ofc) as an OMERO table. The `trackedFeatureInfo` and `trackedFeatureIndx` arrays are stored, respectively, in a `LongArrayColumn` and a `DoubleArrayColumn`.
